### PR TITLE
Trim spaces on the left and on the right sides

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,6 @@
-version = '0.3.1'
+version = '0.4.0'
+
+import os
 
 common_cflags = '-g -O2 -D_GNU_SOURCE -Wall -Wextra -Wmissing-prototypes ' + \
                 '-Wno-sign-compare -Wno-char-subscripts -Wno-unused-parameter'
@@ -12,13 +14,14 @@ AddOption('--libdir', dest='libdir', type='string', nargs=1, action='store',
 
 env = Environment(PREFIX=GetOption('prefix'),
                   LIBDIR=GetOption('libdir'),
-                  SHLIBVERSION=version)
+                  SHLIBVERSION=version,
+                  CFLAGS=os.environ.get('CFLAGS',''))
 
 libzxcvbn = env.SharedLibrary('zxcvbn', 'zxcvbn.c',
-                              CFLAGS=common_cflags)
+                              CFLAGS=common_cflags + ' $CFLAGS')
 zxcvbn_cli = env.Program('zxcvbn_cli', 'zxcvbn_cli.c',
                          LIBS=['zxcvbn', 'm'], LIBPATH='.',
-                         CFLAGS=common_cflags)
+                         CFLAGS=common_cflags + ' $CFLAGS')
 Default([libzxcvbn, zxcvbn_cli])
 
 env.Alias('install', [env.InstallVersionedLib('$LIBDIR', libzxcvbn),

--- a/zxcvbn.h
+++ b/zxcvbn.h
@@ -28,6 +28,7 @@ struct zxcvbn_opts {
     zxcvbn_free_t       free;
     const char         *symbols;
     unsigned int        max_matches_num;
+    unsigned int        skipped_match_types;
 };
 
 struct zxcvbn_date {
@@ -67,6 +68,7 @@ struct zxcvbn {
     struct zxcvbn_spatial_graph spatial_graph_keypad;
     struct zxcvbn_spatial_graph spatial_graph_macpad;
     unsigned int max_matches_num;
+    unsigned int skipped_match_types;
 };
 
 enum zxcvbn_match_type {
@@ -78,6 +80,15 @@ enum zxcvbn_match_type {
     ZXCVBN_MATCH_TYPE_REPEAT,
     ZXCVBN_MATCH_TYPE_BRUTEFORCE,
 };
+
+// match type masks
+#define ZXCVBN_MATCH_TYPE_SPATIAL_M     (1 << ZXCVBN_MATCH_TYPE_SPATIAL)
+#define ZXCVBN_MATCH_TYPE_DIGITS_M      (1 << ZXCVBN_MATCH_TYPE_DIGITS)
+#define ZXCVBN_MATCH_TYPE_DATE_M        (1 << ZXCVBN_MATCH_TYPE_DATE)
+#define ZXCVBN_MATCH_TYPE_SEQUENCE_M    (1 << ZXCVBN_MATCH_TYPE_SEQUENCE)
+#define ZXCVBN_MATCH_TYPE_REPEAT_M      (1 << ZXCVBN_MATCH_TYPE_REPEAT)
+#define ZXCVBN_MATCH_TYPE_DICT_M        (1 << ZXCVBN_MATCH_TYPE_DICT)
+#define ZXCVBN_MATCH_TYPE_BRUTEFORCE_M  (1 << ZXCVBN_MATCH_TYPE_BRUTEFORCE)
 
 #define ZXCVBN_MATCH_DESC_SEQ   (1 << 0)
 

--- a/zxcvbn_cli.c
+++ b/zxcvbn_cli.c
@@ -32,7 +32,7 @@ trim(char *string)
         ++e;
     }
 
-    string[e - b] = '\0';
+    *e = '\0';
 
     return b;
 }


### PR DESCRIPTION
Hello guys, please consider the fix.
Before fix: 
trim("   abc   ") -> returns "" that looks incorrectly.
trim(" abc   ") -> returns "ab" that looks incorrectly.
After fix: 
trim("   abc   ") -> returns "abc" that looks correctly.
trim(" abc   ") -> returns "abc" that looks correctly.
